### PR TITLE
bumping version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhai-ml"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Chris McComb <ccmcc2012@gmail.com>"]
 description = "Machine learning in the Rhai scripting language"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ scripting language. For a complete API reference, check [the docs](https://docs.
 To use the latest released version of `rhai-ml`, add this to your `Cargo.toml`:
 
 ```toml
-rhai-ml = "0.1.1"
+rhai-ml = "0.1.2"
 ```
 
 To use the bleeding edge instead, add this:


### PR DESCRIPTION
Bumping version number to publish zero-length array fix